### PR TITLE
Improve homepage with dark mode toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -410,3 +410,30 @@ h1 {
     width: 430px;
 }
 /*flappy-section__________________________________________________________________ */
+
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #121212;
+    color: #f5f5f5;
+}
+
+body.dark-mode .navbar {
+    background-color: #222;
+}
+
+body.dark-mode .navbar a,
+body.dark-mode .navbar button {
+    background-color: #222;
+    color: #f5f5f5;
+}
+
+body.dark-mode .manager {
+    background-color: #333;
+    border-color: #555;
+}
+
+body.dark-mode input[type="text"] {
+    background-color: #222;
+    color: #f5f5f5;
+    border-color: #555;
+}

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <a href="https://mail.google.com/mail/u/0/#inbox" target="_blank">Gmail</a>
         <a href="https://chatgpt.com/" target="_blank">GPT</a>
         <a href="https://github.com/SjaakieChen/Homepage" target="_blank">Code</a>
+        <button id="darkModeToggle">Dark Mode</button>
         
         
     </div>

--- a/javascript/script.js
+++ b/javascript/script.js
@@ -1,6 +1,9 @@
 //initialize________________________________________________________________
     document.addEventListener('DOMContentLoaded', function() {
         loadTasks();        // Load saved tasks
+        if (localStorage.getItem('darkMode') === 'true') {
+            document.body.classList.add('dark-mode');
+        }
         attachEventListeners(); // Attach event listeners to various elements
     });
     initializePositions();
@@ -10,12 +13,33 @@
 
     
 // navbar url function
-    function goToUrl() {
-        const url = document.getElementById('urlInput').value;
-        if (url) {
-            window.open(url, '_blank').focus();
-        }
+function goToUrl() {
+    const url = document.getElementById('urlInput').value;
+    if (url) {
+        window.open(url, '_blank').focus();
     }
+}
+
+function attachEventListeners() {
+    const taskInput = document.getElementById('taskInput');
+    if (taskInput) {
+        taskInput.addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                addTask();
+            }
+        });
+    }
+    const toggleButton = document.getElementById('darkModeToggle');
+    if (toggleButton) {
+        toggleButton.addEventListener('click', toggleDarkMode);
+    }
+}
+
+function toggleDarkMode() {
+    document.body.classList.toggle('dark-mode');
+    localStorage.setItem('darkMode', document.body.classList.contains('dark-mode'));
+}
 
 
 
@@ -382,9 +406,12 @@ function loadPlayerState() {
     if (savedCurrentTime !== null) {
         player.currentTime = parseFloat(savedCurrentTime);
     }
-    if (currentTrack !== null) {
-        player.currentTrack = parseFloat(savedCurrentTrack);
-        source.src = playlist[currentTrack];
+    if (savedCurrentTrack !== null) {
+        currentTrack = playlist.indexOf(savedCurrentTrack);
+        if (currentTrack === -1) {
+            currentTrack = 0;
+        }
+        source.src = savedCurrentTrack;
     }
 
 }


### PR DESCRIPTION
## Summary
- add dark mode toggle button in navbar
- support dark theme styles in CSS
- wire up new event listeners in JavaScript
- persist dark mode preference and fix music player state load

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683b30a6fa648327979f239d4c99221c